### PR TITLE
docs: add Kimi K2.7 Code OpenClaw result

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Tasks](https://img.shields.io/badge/Tasks-60-blue)]()
 [![Harnesses](https://img.shields.io/badge/Harnesses-4-purple)]()
-[![Models](https://img.shields.io/badge/Models-27-green)]()
+[![Models](https://img.shields.io/badge/Models-28-green)]()
 [![Leaderboard](https://img.shields.io/badge/🏆_Leaderboard-WildClawBench-8c2416)](https://internlm.github.io/WildClawBench/)
 <br>
 [![arXiv](https://img.shields.io/badge/arXiv-2605.10912-b31b1b.svg)](https://arxiv.org/abs/2605.10912)
@@ -88,22 +88,24 @@ Full interactive leaderboard at [internlm.github.io/WildClawBench](https://inter
 | 11 | GPT-5.4 | OpenAI | 50.3% | 350 min | $19.80 |
 | 12 | Hy3 | Tencent | 49.7% | 338 min | $2.13 |
 | 13 | GLM 5.1 | Zhipu AI | 48.2% | 515 min | $34.80 |
-| 14 | DeepSeek V4 Pro | DeepSeek | 43.7% | 605 min | $12.00 |
-| 15 | MiMo V2.5 Pro | Xiaomi | 43.0% | 451 min | $12.60 |
-| 16 | GLM 5 | Zhipu AI | 42.6% | 373 min | $11.40 |
-| 17 | Gemini 3.1 Pro | Google DeepMind | 40.8% | 240 min | $18.00 |
-| 18 | MiMo V2 Pro | Xiaomi | 40.2% | 458 min | $26.40 |
-| 19 | Qwen3.5 397B | Alibaba Cloud | 34.5% | 459 min | $22.20 |
-| 20 | DeepSeek V3.2 | DeepSeek | 34.0% | 549 min | $11.40 |
-| 21 | GLM 5 Turbo | Zhipu AI | 33.9% | 499 min | $15.00 |
-| 22 | MiniMax M2.7 | MiniMax | 33.8% | 551 min | $7.20 |
-| 23 | Kimi K2.5 | Moonshot AI | 30.8% | 406 min | $6.60 |
-| 24 | MiMo V2 Flash | Xiaomi | 30.8% | 433 min | $10.20 |
-| 25 | MiniMax M2.5 | MiniMax | 27.1% | 542 min | $9.60 |
-| 26 | Step 3.5 Flash | StepFun | 26.7% | 430 min | $6.60 |
-| 27 | Grok 4.20 Beta | xAI | 19.3% | 94 min | $9.60 |
+| 14 | **Kimi K2.7 Code** | Moonshot AI | 46.9% | 674 min | $72.31 |
+| 15 | DeepSeek V4 Pro | DeepSeek | 43.7% | 605 min | $12.00 |
+| 16 | MiMo V2.5 Pro | Xiaomi | 43.0% | 451 min | $12.60 |
+| 17 | GLM 5 | Zhipu AI | 42.6% | 373 min | $11.40 |
+| 18 | Gemini 3.1 Pro | Google DeepMind | 40.8% | 240 min | $18.00 |
+| 19 | MiMo V2 Pro | Xiaomi | 40.2% | 458 min | $26.40 |
+| 20 | Qwen3.5 397B | Alibaba Cloud | 34.5% | 459 min | $22.20 |
+| 21 | DeepSeek V3.2 | DeepSeek | 34.0% | 549 min | $11.40 |
+| 22 | GLM 5 Turbo | Zhipu AI | 33.9% | 499 min | $15.00 |
+| 23 | MiniMax M2.7 | MiniMax | 33.8% | 551 min | $7.20 |
+| 24 | Kimi K2.5 | Moonshot AI | 30.8% | 406 min | $6.60 |
+| 25 | MiMo V2 Flash | Xiaomi | 30.8% | 433 min | $10.20 |
+| 26 | MiniMax M2.5 | MiniMax | 27.1% | 542 min | $9.60 |
+| 27 | Step 3.5 Flash | StepFun | 26.7% | 430 min | $6.60 |
+| 28 | Grok 4.20 Beta | xAI | 19.3% | 94 min | $9.60 |
 
 > Claude Opus 4.8 cost uses the dynamic base-tier rates for this evaluation: $5/M input, $25/M output, $0.5/M cache read, and $6.25/M cache write.
+> Kimi K2.7 Code cost uses the published rates for this evaluation: $6.5/M input, $27/M output, and $1.3/M cached input.
 
 ### Harness comparison
 


### PR DESCRIPTION
Adds the Kimi K2.7 Code OpenClaw evaluation result to the leaderboard README, including overall score, elapsed time, and cost under the published dynamic pricing rates.