### PR TITLE
feat: make in-container grading timeout configurable via GRADING_TIMEOUT

### DIFF
--- a/src/utils/grading.py
+++ b/src/utils/grading.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 load_dotenv()
 TMP_WORKSPACE = os.environ.get("TMP_WORKSPACE", "/tmp_workspace")
+GRADING_TIMEOUT = int(os.environ.get("GRADING_TIMEOUT", "120"))
 
 def _write_score(output_dir: Path, task_id: str, scores: dict) -> None:
     score_path = output_dir / "score.json"
@@ -131,7 +132,7 @@ def run_grading(
             ["docker", "exec", *env_args, task_id, "python3", "/tmp/_grade_runner.py"],
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=GRADING_TIMEOUT,
         )
         if r.returncode != 0:
             logger.error("[%s] Grading script execution failed: %s", task_id, r.stderr)


### PR DESCRIPTION
The 120s hardcoded timeout for the grading runner (docker exec ... python3/tmp/_grade_runner.py) is too short for tasks whose graders make several VLM/LLM calls (e.g. 05_Creative_Synthesis_task_10_social_poster_multi_crop calls the VLM 6 times with multi-MB base64 images). Allow operators to override it via GRADING_TIMEOUT (seconds), defaulting to 120.