### PR TITLE
docs: add Qwen3.8 27B OpenClaw result

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Tasks](https://img.shields.io/badge/Tasks-60-blue)]()
 [![Harnesses](https://img.shields.io/badge/Harnesses-4-purple)]()
-[![Models](https://img.shields.io/badge/Models-32-green)]()
+[![Models](https://img.shields.io/badge/Models-33-green)]()
 [![Leaderboard](https://img.shields.io/badge/🏆_Leaderboard-WildClawBench-8c2416)](https://internlm.github.io/WildClawBench/)
 <br>
 [![arXiv](https://img.shields.io/badge/arXiv-2605.10912-b31b1b.svg)](https://arxiv.org/abs/2605.10912)
@@ -104,29 +104,31 @@ Full interactive leaderboard at [internlm.github.io/WildClawBench](https://inter
 | 12 | GPT-5.4 | OpenAI | 50.3% | 350 min | $19.80 |
 | 13 | Hy3 | Tencent | 49.7% | 338 min | $2.13 |
 | 14 | GLM 5.1 | Zhipu AI | 48.2% | 515 min | $34.80 |
-| 15 | Muse Glimmer 30B | Meta | 47.6% | 352 min | $6.06 |
-| 16 | Kimi K2.7 Code | Moonshot AI | 46.9% | 674 min | $72.31 |
-| 17 | DeepSeek V4 Pro | DeepSeek | 43.7% | 605 min | $12.00 |
-| 18 | Qwen3.6 27B | Alibaba Cloud | 43.2% | 421 min | $20.91 |
-| 19 | MiMo V2.5 Pro | Xiaomi | 43.0% | 451 min | $12.60 |
-| 20 | GLM 5 | Zhipu AI | 42.6% | 373 min | $11.40 |
-| 21 | Gemini 3.1 Pro | Google DeepMind | 40.8% | 240 min | $18.00 |
-| 22 | MiMo V2 Pro | Xiaomi | 40.2% | 458 min | $26.40 |
-| 23 | Gemma 4 31B IT | Google DeepMind | 37.6% | 384 min | $3.46 |
-| 24 | Qwen3.5 397B | Alibaba Cloud | 34.5% | 459 min | $22.20 |
-| 25 | DeepSeek V3.2 | DeepSeek | 34.0% | 549 min | $11.40 |
-| 26 | GLM 5 Turbo | Zhipu AI | 33.9% | 499 min | $15.00 |
-| 27 | MiniMax M2.7 | MiniMax | 33.8% | 551 min | $7.20 |
-| 28 | Kimi K2.5 | Moonshot AI | 30.8% | 406 min | $6.60 |
-| 29 | MiMo V2 Flash | Xiaomi | 30.8% | 433 min | $10.20 |
-| 30 | MiniMax M2.5 | MiniMax | 27.1% | 542 min | $9.60 |
-| 31 | Step 3.5 Flash | StepFun | 26.7% | 430 min | $6.60 |
-| 32 | Grok 4.20 Beta | xAI | 19.3% | 94 min | $9.60 |
+| 15 | Qwen3.8 27B | Alibaba Cloud | 48.0% | 516 min | N/A |
+| 16 | Muse Glimmer 30B | Meta | 47.6% | 352 min | $6.06 |
+| 17 | Kimi K2.7 Code | Moonshot AI | 46.9% | 674 min | $72.31 |
+| 18 | DeepSeek V4 Pro | DeepSeek | 43.7% | 605 min | $12.00 |
+| 19 | Qwen3.6 27B | Alibaba Cloud | 43.2% | 421 min | $20.91 |
+| 20 | MiMo V2.5 Pro | Xiaomi | 43.0% | 451 min | $12.60 |
+| 21 | GLM 5 | Zhipu AI | 42.6% | 373 min | $11.40 |
+| 22 | Gemini 3.1 Pro | Google DeepMind | 40.8% | 240 min | $18.00 |
+| 23 | MiMo V2 Pro | Xiaomi | 40.2% | 458 min | $26.40 |
+| 24 | Gemma 4 31B IT | Google DeepMind | 37.6% | 384 min | $3.46 |
+| 25 | Qwen3.5 397B | Alibaba Cloud | 34.5% | 459 min | $22.20 |
+| 26 | DeepSeek V3.2 | DeepSeek | 34.0% | 549 min | $11.40 |
+| 27 | GLM 5 Turbo | Zhipu AI | 33.9% | 499 min | $15.00 |
+| 28 | MiniMax M2.7 | MiniMax | 33.8% | 551 min | $7.20 |
+| 29 | Kimi K2.5 | Moonshot AI | 30.8% | 406 min | $6.60 |
+| 30 | MiMo V2 Flash | Xiaomi | 30.8% | 433 min | $10.20 |
+| 31 | MiniMax M2.5 | MiniMax | 27.1% | 542 min | $9.60 |
+| 32 | Step 3.5 Flash | StepFun | 26.7% | 430 min | $6.60 |
+| 33 | Grok 4.20 Beta | xAI | 19.3% | 94 min | $9.60 |
 
 > Claude Opus 4.8 cost uses the dynamic base-tier rates for this evaluation: $5/M input, $25/M output, $0.5/M cache read, and $6.25/M cache write.
 > Muse Glimmer 30B cost uses the OpenRouter rates for this evaluation: $0.35/M input, $1.50/M output, and $0.04/M cache read.
 > Kimi K2.7 Code cost uses the published rates for this evaluation: $6.5/M input, $27/M output, and $1.3/M cached input.
 > Qwen3.8-Max cost uses the evaluation rates: $1.7535/M input, $5.2605/M output, and $0.219186/M cache read.
+> Qwen3.8 27B was evaluated on a self-hosted vLLM endpoint. Token-level billing data was unavailable, so total cost is reported as N/A.
 
 ### Harness comparison
 


### PR DESCRIPTION
## Summary
- add Qwen3.8 27B to the OpenClaw model leaderboard
- update the model count from 32 to 33
- report self-hosted vLLM cost as N/A because token-level billing data was unavailable

## Audited result
- Overall: 48.0152% across 60/60 scored tasks
- Total elapsed time: 30,970.93 seconds (516 minutes)
- Total cost: N/A (self-hosted vLLM endpoint; no token/billing usage returned)

This submission uses the unmerged third full run with timeout multiplier 1.0; no task-level score selection or rerun replacement was applied.