### PR TITLE
web: add Qwen3.8 27B leaderboard result

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,11 +528,11 @@ tbody tr:nth-child(9){animation-delay:.18s}tbody tr:nth-child(10){animation-dela
         <div class="hp-title">
           <span class="hp-wild">Wild</span><span class="hp-claw">Claw</span><span class="hp-bench">Bench</span>
         </div>
-        <div class="hp-sub">A harder, wilder benchmark for autonomous AI agents — testing real-world task completion across 32 frontier models on the OpenClaw harness.</div>
+        <div class="hp-sub">A harder, wilder benchmark for autonomous AI agents — testing real-world task completion across 33 frontier models on the OpenClaw harness.</div>
       </div>
       <div class="hp-stats">
         <div class="hps">
-          <span class="hps-val red">32</span>
+          <span class="hps-val red">33</span>
           <span class="hps-label">Models</span>
         </div>
         <div class="hps">
@@ -745,7 +745,7 @@ tbody tr:nth-child(9){animation-delay:.18s}tbody tr:nth-child(10){animation-dela
     <div class="hp-stats">
       <div class="hps"><span class="hps-val red">6</span><span class="hps-label">Categories</span></div>
       <div class="hps"><span class="hps-val">60</span><span class="hps-label">Total Tasks</span></div>
-      <div class="hps"><span class="hps-val red">32</span><span class="hps-label">Models</span></div>
+      <div class="hps"><span class="hps-val red">33</span><span class="hps-label">Models</span></div>
     </div>
   </div>
 
@@ -805,7 +805,7 @@ tbody tr:nth-child(9){animation-delay:.18s}tbody tr:nth-child(10){animation-dela
     <p>The tasks aren't exotic. They're the kind of work a competent human assistant handles every day. That gap is what makes WildClawBench useful.</p>
 
     <div class="blog-stat-strip">
-      <div class="blog-stat"><div class="blog-stat-val">32</div><div class="blog-stat-label">Frontier Models</div></div>
+      <div class="blog-stat"><div class="blog-stat-val">33</div><div class="blog-stat-label">Frontier Models</div></div>
       <div class="blog-stat"><div class="blog-stat-val">60</div><div class="blog-stat-label">Hand-crafted Tasks</div></div>
       <div class="blog-stat"><div class="blog-stat-val">67.2%</div><div class="blog-stat-label">Top Score</div></div>
       <div class="blog-stat"><div class="blog-stat-val">6</div><div class="blog-stat-label">Task Categories</div></div>
@@ -979,6 +979,7 @@ const MODELS=[
   {id:3,name:'GPT-5.4',          org:'OpenAI',         prov:'OpenAI',   color:'#304860',successRate:50.30, elapsed:21000, cost:19.800, change: 0,cat:'gpt'},
   {id:25,name:'Hy3',             org:'Tencent',        prov:'Tencent',  color:'#d94841',successRate:49.70, elapsed:20288, cost: 2.126, change: 0,cat:'other'},
   {id:4,name:'GLM 5.1',          org:'Zhipu AI',       prov:'Zhipu',    color:'#2d5070',successRate:48.20, elapsed:30900, cost:34.800, change: 0,cat:'other'},
+  {id:32,name:'Qwen3.8 27B',      org:'Alibaba Cloud',  prov:'Alibaba',  color:'#4338ca',successRate:48.015167,elapsed:30970.93,cost:null,change: 0,cat:'other'},
   {id:28,name:'Muse Glimmer 30B',org:'Meta',           prov:'Meta',     color:'#4f63c6',successRate:47.621833,elapsed:21102.2167,cost:6.057658, change: 0,cat:'meta'},
   {id:27,name:'Kimi K2.7 Code',   org:'Moonshot AI',    prov:'Moonshot', color:'#7c3aed',successRate:46.895, elapsed:40436.62,cost:72.309242, change: 0,cat:'other'},
   {id:5,name:'DeepSeek V4 Pro',  org:'DeepSeek',       prov:'DeepSeek', color:'#2563a8',successRate:43.70, elapsed:36300, cost:12.000, change: 0,cat:'deepseek'},
@@ -1007,6 +1008,7 @@ const AXES={successRate:{label:'Overall Score',fmt:v=>v.toFixed(1)+'%'},elapsed:
 /* Split scores use the released paper values or task-level means from the
    evaluation bundle. Elapsed time and cost splits sum to the released totals. */
 const SPLIT_SCORES={
+  32: {mm:39.078462, pt:54.849118, mmElapsed:19819.60, ptElapsed:11151.33, mmCost:null, ptCost:null}, // Qwen3.8 27B (self-hosted vLLM; billing data unavailable)
   31: {mm:59.423077, pt:53.656176, mmElapsed:29050.87, ptElapsed:13404.86, mmCost:14.937335, ptCost:9.762950}, // Qwen3.8-Max ($1.7535/M input, $5.2605/M output, $0.219186/M cache read)
   28: {mm:46.638333, pt:48.373922, mmElapsed:11950.6800, ptElapsed:9151.5367, mmCost:2.572105, ptCost:3.485553}, // Muse Glimmer 30B (OpenRouter rate estimate: $0.35/M input, $1.50/M output, $0.04/M cache read)
   29: {mm:38.220769, pt:47.006275, mmElapsed:17592.2233, ptElapsed:7641.2333, mmCost:8.949735, ptCost:11.959653}, // Qwen3.6 27B (OpenRouter rate estimate)
@@ -1080,6 +1082,7 @@ const CATEGORIES=
       {modelId:26,rate:73.04,elapsed:5612.74,cost:21.518},
       {modelId:27,rate:38.96,elapsed:8430.47,cost:19.638295},
       {modelId:31,rate:46.202,elapsed:7261.30,cost:5.164222},
+      {modelId:32,rate:45.701,elapsed:6281.49,cost:null},
     ]
   },
   {
@@ -1111,6 +1114,7 @@ const CATEGORIES=
       {modelId:26,rate:74.89,elapsed:6259.18,cost:19.176},
       {modelId:27,rate:53.58,elapsed:13297.07,cost:21.806547},
       {modelId:31,rate:55.719167,elapsed:10446.86,cost:6.517370},
+      {modelId:32,rate:50.535,elapsed:9860.87,cost:null},
     ]
   },
   {
@@ -1142,6 +1146,7 @@ const CATEGORIES=
       {modelId:26,rate:91.86,elapsed:1338.79,cost:5.684},
       {modelId:27,rate:81.56,elapsed:1905.37,cost:7.358151},
       {modelId:31,rate:32.048333,elapsed:1151.30,cost:0.842572},
+      {modelId:32,rate:87.643333,elapsed:1427.48,cost:null},
     ]
   },
   {
@@ -1173,6 +1178,7 @@ const CATEGORIES=
       {modelId:26,rate:45.91,elapsed:3716.17,cost:8.809},
       {modelId:27,rate:53.64,elapsed:5502.42,cost:11.339409},
       {modelId:31,rate:81.818182,elapsed:3682.10,cost:2.424367},
+      {modelId:32,rate:44.545455,elapsed:3736.52,cost:null},
     ]
   },
   {
@@ -1204,6 +1210,7 @@ const CATEGORIES=
       {modelId:26,rate:61.66,elapsed:6452.59,cost:35.378},
       {modelId:27,rate:31.98,elapsed:9596.74,cost:8.993809},
       {modelId:31,rate:66.033636,elapsed:17495.35,cost:7.907456},
+      {modelId:32,rate:32.874545,elapsed:8590.72,cost:null},
     ]
   },
   {
@@ -1235,6 +1242,7 @@ const CATEGORIES=
       {modelId:26,rate:52.00,elapsed:640.39,cost:5.389},
       {modelId:27,rate:35.00,elapsed:1704.55,cost:3.173030},
       {modelId:31,rate:42.000000,elapsed:2418.82,cost:1.844297},
+      {modelId:32,rate:44.000000,elapsed:1073.85,cost:null},
     ]
   },
 ];


### PR DESCRIPTION
## Summary
- add Qwen3.8 27B to the interactive leaderboard
- update all model-count displays from 32 to 33
- add multimodal/pure-text split metrics
- add all six category score and elapsed-time entries
- display cost as N/A because this self-hosted vLLM run returned no token-level billing data

## Audited result
- Overall: 48.0152%, 30,970.93 seconds
- Multimodal (26 tasks): 39.0785%, 19,819.60 seconds
- Pure text (34 tasks): 54.8491%, 11,151.33 seconds
- Category scores: 45.7010 / 50.5350 / 87.6433 / 44.5455 / 32.8745 / 44.0000

All split/category weighted totals were checked against the 60-task summary.