### PR TITLE
docs: add Intern-S2 Preview 397B OpenClaw result

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Tasks](https://img.shields.io/badge/Tasks-60-blue)]()
 [![Harnesses](https://img.shields.io/badge/Harnesses-4-purple)]()
-[![Models](https://img.shields.io/badge/Models-33-green)]()
+[![Models](https://img.shields.io/badge/Models-34-green)]()
 [![Leaderboard](https://img.shields.io/badge/🏆_Leaderboard-WildClawBench-8c2416)](https://internlm.github.io/WildClawBench/)
 <br>
 [![arXiv](https://img.shields.io/badge/arXiv-2605.10912-b31b1b.svg)](https://arxiv.org/abs/2605.10912)
@@ -107,22 +107,23 @@ Full interactive leaderboard at [internlm.github.io/WildClawBench](https://inter
 | 15 | Qwen3.8 27B | Alibaba Cloud | 48.0% | 516 min | N/A |
 | 16 | Muse Glimmer 30B | Meta | 47.6% | 352 min | $6.06 |
 | 17 | Kimi K2.7 Code | Moonshot AI | 46.9% | 674 min | $72.31 |
-| 18 | DeepSeek V4 Pro | DeepSeek | 43.7% | 605 min | $12.00 |
-| 19 | Qwen3.6 27B | Alibaba Cloud | 43.2% | 421 min | $20.91 |
-| 20 | MiMo V2.5 Pro | Xiaomi | 43.0% | 451 min | $12.60 |
-| 21 | GLM 5 | Zhipu AI | 42.6% | 373 min | $11.40 |
-| 22 | Gemini 3.1 Pro | Google DeepMind | 40.8% | 240 min | $18.00 |
-| 23 | MiMo V2 Pro | Xiaomi | 40.2% | 458 min | $26.40 |
-| 24 | Gemma 4 31B IT | Google DeepMind | 37.6% | 384 min | $3.46 |
-| 25 | Qwen3.5 397B | Alibaba Cloud | 34.5% | 459 min | $22.20 |
-| 26 | DeepSeek V3.2 | DeepSeek | 34.0% | 549 min | $11.40 |
-| 27 | GLM 5 Turbo | Zhipu AI | 33.9% | 499 min | $15.00 |
-| 28 | MiniMax M2.7 | MiniMax | 33.8% | 551 min | $7.20 |
-| 29 | Kimi K2.5 | Moonshot AI | 30.8% | 406 min | $6.60 |
-| 30 | MiMo V2 Flash | Xiaomi | 30.8% | 433 min | $10.20 |
-| 31 | MiniMax M2.5 | MiniMax | 27.1% | 542 min | $9.60 |
-| 32 | Step 3.5 Flash | StepFun | 26.7% | 430 min | $6.60 |
-| 33 | Grok 4.20 Beta | xAI | 19.3% | 94 min | $9.60 |
+| 18 | Intern-S2 Preview 397B | InternLM | 44.7% | 541 min | Free |
+| 19 | DeepSeek V4 Pro | DeepSeek | 43.7% | 605 min | $12.00 |
+| 20 | Qwen3.6 27B | Alibaba Cloud | 43.2% | 421 min | $20.91 |
+| 21 | MiMo V2.5 Pro | Xiaomi | 43.0% | 451 min | $12.60 |
+| 22 | GLM 5 | Zhipu AI | 42.6% | 373 min | $11.40 |
+| 23 | Gemini 3.1 Pro | Google DeepMind | 40.8% | 240 min | $18.00 |
+| 24 | MiMo V2 Pro | Xiaomi | 40.2% | 458 min | $26.40 |
+| 25 | Gemma 4 31B IT | Google DeepMind | 37.6% | 384 min | $3.46 |
+| 26 | Qwen3.5 397B | Alibaba Cloud | 34.5% | 459 min | $22.20 |
+| 27 | DeepSeek V3.2 | DeepSeek | 34.0% | 549 min | $11.40 |
+| 28 | GLM 5 Turbo | Zhipu AI | 33.9% | 499 min | $15.00 |
+| 29 | MiniMax M2.7 | MiniMax | 33.8% | 551 min | $7.20 |
+| 30 | Kimi K2.5 | Moonshot AI | 30.8% | 406 min | $6.60 |
+| 31 | MiMo V2 Flash | Xiaomi | 30.8% | 433 min | $10.20 |
+| 32 | MiniMax M2.5 | MiniMax | 27.1% | 542 min | $9.60 |
+| 33 | Step 3.5 Flash | StepFun | 26.7% | 430 min | $6.60 |
+| 34 | Grok 4.20 Beta | xAI | 19.3% | 94 min | $9.60 |
 
 > Claude Opus 4.8 cost uses the dynamic base-tier rates for this evaluation: $5/M input, $25/M output, $0.5/M cache read, and $6.25/M cache write.
 > Muse Glimmer 30B cost uses the OpenRouter rates for this evaluation: $0.35/M input, $1.50/M output, and $0.04/M cache read.


### PR DESCRIPTION
## Summary
- add Intern-S2 Preview 397B to the OpenClaw leaderboard
- update the model count from 33 to 34
- report the self-hosted evaluation cost as Free

## Audited result
- Overall: 44.6787% across 60/60 scored tasks
- Total elapsed time: 32,481.83 seconds (541 minutes)
- Total cost: Free

The submitted bundle is the audited consolidated 60-task result.